### PR TITLE
Add barwert chart toggle and Jotai state sync

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,9 +6,11 @@ export default defineSchema({
     userIdentifier: v.string(),
     activeScenarioId: v.string(),
     comparedScenarioIds: v.array(v.string()),
+    detailScenarioId: v.optional(v.string()),
     activeLiquidityScenarioId: v.string(),
     includeRefinancing: v.boolean(),
     analysisHorizonYears: v.number(),
+    opportunityRate: v.optional(v.number()),
     updatedAt: v.number(),
   }).index("by_userIdentifier", ["userIdentifier"]),
   financingScenarios: defineTable({

--- a/src/app/finanzplan/page.tsx
+++ b/src/app/finanzplan/page.tsx
@@ -1111,6 +1111,23 @@ export default function FinanzplanPage() {
     });
   }, [calculationOptions, comparisonRows, maxComparisonYears, scenarioValues]);
 
+  const singleScenarioMonthlyRateChart = useMemo(() => {
+    if (comparisonRows.length !== 1) return undefined;
+    const scenarioId = comparisonRows[0]!.id;
+    const values = scenarioValues[scenarioId];
+    if (!values) return undefined;
+    const stack = calculateDetailMonthlyRateStack(
+      values,
+      maxComparisonYears,
+      calculationOptions,
+    );
+    return {
+      chartConfig: stack.chartConfig,
+      chartData: stack.chartData,
+      seriesKeys: stack.creditSeries.map((series) => series.key),
+    };
+  }, [calculationOptions, comparisonRows, maxComparisonYears, scenarioValues]);
+
   const presentValueCostChartData = useMemo(() => {
     const opportunityRates = Array.from(
       { length: 17 },
@@ -1257,6 +1274,7 @@ export default function FinanzplanPage() {
             chartData={chartData}
             presentValueCostData={presentValueCostChartData}
             scenarioIds={comparisonRows.map((scenario) => scenario.id)}
+            singleScenarioMonthlyRate={singleScenarioMonthlyRateChart}
           />
 
           <div className="space-y-2 sm:hidden">

--- a/src/app/finanzplan/page.tsx
+++ b/src/app/finanzplan/page.tsx
@@ -656,6 +656,58 @@ function calculateScenarioMonthlyRateSeries(
   });
 }
 
+function calculateScenarioPresentValueCost(
+  values: ScenarioValues,
+  opportunityRate: number,
+  options: CalculationOptions,
+) {
+  const credits = Object.values(values.credits ?? {});
+  const nettoDarlehensbetragBank =
+    values.kaufpreis +
+    values.modernisierungskosten +
+    values.kaufpreis * 0.1207 -
+    values.eigenkapital -
+    credits.reduce((acc, credit) => acc + credit.summeDarlehen, 0);
+  const totalBorrowed =
+    nettoDarlehensbetragBank +
+    credits.reduce((acc, credit) => acc + credit.summeDarlehen, 0);
+  const result = calculateScenarioFinanzplan(values, options);
+  const horizonYears = Math.max(
+    1,
+    ...result.finanzplanRows.map((row) => row.stichtag),
+  );
+  const monthlyRates = calculateScenarioMonthlyRateSeries(
+    values,
+    horizonYears,
+    options,
+  );
+  const monthlyDiscountRate = Math.pow(1 + opportunityRate / 100, 1 / 12) - 1;
+  const discountFactor = (months: number) =>
+    Math.pow(1 + monthlyDiscountRate, months);
+  const presentValueOfRates = monthlyRates.reduce((sum, row, yearIndex) => {
+    let yearValue = 0;
+    for (let month = 1; month <= 12; month += 1) {
+      yearValue += row.monthlyRate / discountFactor(yearIndex * 12 + month);
+    }
+    return sum + yearValue;
+  }, 0);
+  const presentValueOfResidualDebt = options.includeRefinancing
+    ? (() => {
+        const finalRow = result.finanzplanRows[result.finanzplanRows.length - 1];
+        if (!finalRow) return 0;
+        return (
+          finalRow.restschuldGesamt / discountFactor(finalRow.stichtag * 12)
+        );
+      })()
+    : result.maturityEvents.reduce(
+        (sum, event) =>
+          sum + event.dueAmount / discountFactor(event.dueYear * 12),
+        0,
+      );
+
+  return presentValueOfRates + presentValueOfResidualDebt - totalBorrowed;
+}
+
 function calculateDetailRestschuldStack(
   values: ScenarioValues,
   maxYears: number,
@@ -1059,6 +1111,28 @@ export default function FinanzplanPage() {
     });
   }, [calculationOptions, comparisonRows, maxComparisonYears, scenarioValues]);
 
+  const presentValueCostChartData = useMemo(() => {
+    const opportunityRates = Array.from(
+      { length: 17 },
+      (_, index) => index * 0.5,
+    );
+
+    return opportunityRates.map((opportunityRate) => {
+      const row: Record<string, number> & { opportunityRate: number } = {
+        opportunityRate,
+      };
+      comparisonRows.forEach((scenario) => {
+        const values = scenarioValues[scenario.id] ?? defaultScenarioValues;
+        row[scenario.id] = calculateScenarioPresentValueCost(
+          values,
+          opportunityRate,
+          calculationOptions,
+        );
+      });
+      return row;
+    });
+  }, [calculationOptions, comparisonRows, scenarioValues]);
+
   const comparisonBaseId = useMemo(() => {
     if (selectedScenarioIds.includes(defaultScenarioId))
       return defaultScenarioId;
@@ -1181,6 +1255,7 @@ export default function FinanzplanPage() {
           <ScenarioMonthlyRateChart
             chartConfig={chartConfig}
             chartData={chartData}
+            presentValueCostData={presentValueCostChartData}
             scenarioIds={comparisonRows.map((scenario) => scenario.id)}
           />
 

--- a/src/components/finanzplan_charts.tsx
+++ b/src/components/finanzplan_charts.tsx
@@ -56,11 +56,17 @@ export function ScenarioMonthlyRateChart({
   chartData,
   presentValueCostData,
   scenarioIds,
+  singleScenarioMonthlyRate,
 }: {
   chartConfig: ChartConfig;
   chartData: YearRow[];
   presentValueCostData: OpportunityRateRow[];
   scenarioIds: string[];
+  singleScenarioMonthlyRate?: {
+    chartConfig: ChartConfig;
+    chartData: YearRow[];
+    seriesKeys: string[];
+  };
 }) {
   const [mode, setMode] = React.useState<"monthlyRate" | "presentValueCost">(
     "monthlyRate",
@@ -69,6 +75,11 @@ export function ScenarioMonthlyRateChart({
   const { chartRef, tooltipActive, reactivateTooltip } =
     useDismissibleChartTooltip();
   const activeData = mode === "monthlyRate" ? chartData : presentValueCostData;
+  const showSingleScenarioStack =
+    mode === "monthlyRate" && singleScenarioMonthlyRate !== undefined;
+  const activeConfig = showSingleScenarioStack
+    ? singleScenarioMonthlyRate.chartConfig
+    : chartConfig;
 
   return (
     <div className="rounded-md border border-neutral-700 bg-neutral-800 p-2 sm:p-3">
@@ -105,61 +116,117 @@ export function ScenarioMonthlyRateChart({
       </div>
       <ChartContainer
         ref={chartRef}
-        config={chartConfig}
+        config={activeConfig}
         className="h-52 w-full sm:h-72"
         onMouseMove={reactivateTooltip}
         onTouchStart={reactivateTooltip}
       >
-        <LineChart
-          data={activeData}
-          margin={{
-            left: isMobile ? 0 : 8,
-            right: isMobile ? 2 : 8,
-            top: 8,
-            bottom: 8,
-          }}
-        >
-          <CartesianGrid vertical={false} />
-          <XAxis
-            dataKey={mode === "monthlyRate" ? "year" : "opportunityRate"}
-            tickLine={false}
-            axisLine={false}
-            tickMargin={8}
-            minTickGap={isMobile ? 20 : 8}
-            tick={{ fontSize: isMobile ? 11 : 12 }}
-            tickFormatter={(value) =>
-              mode === "monthlyRate" ? String(value) : `${value} %`
-            }
-            label={{
-              value: mode === "monthlyRate" ? "Jahr" : "Opportunitaetszins",
-              position: "insideBottom",
-              offset: -5,
+        {showSingleScenarioStack ? (
+          <AreaChart
+            data={singleScenarioMonthlyRate.chartData}
+            margin={{
+              left: isMobile ? 0 : 8,
+              right: isMobile ? 2 : 8,
+              top: 8,
+              bottom: 8,
             }}
-          />
-          <YAxis
-            width={isMobile ? 54 : 96}
-            tickLine={false}
-            axisLine={false}
-            tickMargin={isMobile ? 4 : 8}
-            tick={{ fontSize: isMobile ? 11 : 12 }}
-            tickCount={isMobile ? 4 : 5}
-            tickFormatter={(value) => {
-              const numeric = typeof value === "number" ? value : Number(value);
-              return formatAxisEuro(numeric, isMobile);
-            }}
-          />
-          <Tooltip active={tooltipActive} content={<ChartTooltipContent />} />
-          {scenarioIds.map((scenarioId) => (
-            <Line
-              key={scenarioId}
-              dataKey={scenarioId}
-              type="monotone"
-              stroke={`var(--color-${scenarioId})`}
-              strokeWidth={2}
-              dot={false}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="year"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={isMobile ? 20 : 8}
+              tick={{ fontSize: isMobile ? 11 : 12 }}
+              label={{ value: "Jahr", position: "insideBottom", offset: -5 }}
             />
-          ))}
-        </LineChart>
+            <YAxis
+              width={isMobile ? 54 : 96}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={isMobile ? 4 : 8}
+              tick={{ fontSize: isMobile ? 11 : 12 }}
+              tickCount={isMobile ? 4 : 5}
+              tickFormatter={(value) => {
+                const numeric =
+                  typeof value === "number" ? value : Number(value);
+                return formatAxisEuro(numeric, isMobile);
+              }}
+            />
+            <Tooltip
+              active={tooltipActive}
+              content={
+                <StackedCreditTooltip
+                  chartConfig={singleScenarioMonthlyRate.chartConfig}
+                />
+              }
+            />
+            {singleScenarioMonthlyRate.seriesKeys.map((key) => (
+              <Area
+                key={key}
+                dataKey={key}
+                type="monotone"
+                stackId="monthlyRate"
+                stroke={`var(--color-${key})`}
+                fill={`var(--color-${key})`}
+                fillOpacity={0.25}
+              />
+            ))}
+          </AreaChart>
+        ) : (
+          <LineChart
+            data={activeData}
+            margin={{
+              left: isMobile ? 0 : 8,
+              right: isMobile ? 2 : 8,
+              top: 8,
+              bottom: 8,
+            }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey={mode === "monthlyRate" ? "year" : "opportunityRate"}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={isMobile ? 20 : 8}
+              tick={{ fontSize: isMobile ? 11 : 12 }}
+              tickFormatter={(value) =>
+                mode === "monthlyRate" ? String(value) : `${value} %`
+              }
+              label={{
+                value: mode === "monthlyRate" ? "Jahr" : "Opportunitaetszins",
+                position: "insideBottom",
+                offset: -5,
+              }}
+            />
+            <YAxis
+              width={isMobile ? 54 : 96}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={isMobile ? 4 : 8}
+              tick={{ fontSize: isMobile ? 11 : 12 }}
+              tickCount={isMobile ? 4 : 5}
+              tickFormatter={(value) => {
+                const numeric =
+                  typeof value === "number" ? value : Number(value);
+                return formatAxisEuro(numeric, isMobile);
+              }}
+            />
+            <Tooltip active={tooltipActive} content={<ChartTooltipContent />} />
+            {scenarioIds.map((scenarioId) => (
+              <Line
+                key={scenarioId}
+                dataKey={scenarioId}
+                type="monotone"
+                stroke={`var(--color-${scenarioId})`}
+                strokeWidth={2}
+                dot={false}
+              />
+            ))}
+          </LineChart>
+        )}
       </ChartContainer>
     </div>
   );

--- a/src/components/finanzplan_charts.tsx
+++ b/src/components/finanzplan_charts.tsx
@@ -20,6 +20,7 @@ import {
 } from "~/components/ui/chart";
 
 type YearRow = Record<string, number> & { year: number };
+type OpportunityRateRow = Record<string, number> & { opportunityRate: number };
 
 function useMobileChart() {
   const [isMobile, setIsMobile] = React.useState(false);
@@ -53,21 +54,55 @@ function formatAxisEuro(
 export function ScenarioMonthlyRateChart({
   chartConfig,
   chartData,
+  presentValueCostData,
   scenarioIds,
 }: {
   chartConfig: ChartConfig;
   chartData: YearRow[];
+  presentValueCostData: OpportunityRateRow[];
   scenarioIds: string[];
 }) {
+  const [mode, setMode] = React.useState<"monthlyRate" | "presentValueCost">(
+    "monthlyRate",
+  );
   const isMobile = useMobileChart();
   const { chartRef, tooltipActive, reactivateTooltip } =
     useDismissibleChartTooltip();
+  const activeData = mode === "monthlyRate" ? chartData : presentValueCostData;
 
   return (
     <div className="rounded-md border border-neutral-700 bg-neutral-800 p-2 sm:p-3">
-      <p className="mb-2 text-sm font-medium text-neutral-100">
-        Monatliche Gesamt-Rate im Zeitverlauf
-      </p>
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm font-medium text-neutral-100">
+          {mode === "monthlyRate"
+            ? "Monatliche Gesamt-Rate im Zeitverlauf"
+            : "Barwertkosten nach Opportunitaetszins"}
+        </p>
+        <div className="inline-flex items-center rounded-md border border-neutral-600 bg-neutral-900 p-0.5 text-xs">
+          <button
+            type="button"
+            className={`rounded px-2 py-1 ${
+              mode === "monthlyRate"
+                ? "bg-neutral-100 text-black"
+                : "text-neutral-200"
+            }`}
+            onClick={() => setMode("monthlyRate")}
+          >
+            Monatsrate
+          </button>
+          <button
+            type="button"
+            className={`rounded px-2 py-1 ${
+              mode === "presentValueCost"
+                ? "bg-neutral-100 text-black"
+                : "text-neutral-200"
+            }`}
+            onClick={() => setMode("presentValueCost")}
+          >
+            Barwertkosten
+          </button>
+        </div>
+      </div>
       <ChartContainer
         ref={chartRef}
         config={chartConfig}
@@ -76,7 +111,7 @@ export function ScenarioMonthlyRateChart({
         onTouchStart={reactivateTooltip}
       >
         <LineChart
-          data={chartData}
+          data={activeData}
           margin={{
             left: isMobile ? 0 : 8,
             right: isMobile ? 2 : 8,
@@ -86,13 +121,20 @@ export function ScenarioMonthlyRateChart({
         >
           <CartesianGrid vertical={false} />
           <XAxis
-            dataKey="year"
+            dataKey={mode === "monthlyRate" ? "year" : "opportunityRate"}
             tickLine={false}
             axisLine={false}
             tickMargin={8}
             minTickGap={isMobile ? 20 : 8}
             tick={{ fontSize: isMobile ? 11 : 12 }}
-            label={{ value: "Jahr", position: "insideBottom", offset: -5 }}
+            tickFormatter={(value) =>
+              mode === "monthlyRate" ? String(value) : `${value} %`
+            }
+            label={{
+              value: mode === "monthlyRate" ? "Jahr" : "Opportunitaetszins",
+              position: "insideBottom",
+              offset: -5,
+            }}
           />
           <YAxis
             width={isMobile ? 54 : 96}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -76,6 +76,11 @@ function ChartContainer({
 }) {
   const uniqueId = React.useId();
   const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`;
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -89,9 +94,11 @@ function ChartContainer({
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>
-          {children}
-        </RechartsPrimitive.ResponsiveContainer>
+        {mounted ? (
+          <RechartsPrimitive.ResponsiveContainer width="100%" height="100%">
+            {children}
+          </RechartsPrimitive.ResponsiveContainer>
+        ) : null}
       </div>
     </ChartContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Added a barwert cost chart toggle in the Finanzplan view.
- Refactored app state from the old Convex-centric store to Jotai atoms with Convex sync.
- Updated liquidity and scenario UI/components to use the new state flow and preserve monthly rate chart behavior.
- Removed deprecated scenario evaluation/state modules and aligned dependencies for the new client-side state layer.

## Testing
- Not run.
- Reviewed the diff for updated page/component wiring across Finanzplan, Liquiditaetsplan, and Liquiditaetsauswertung.
- Verified the dependency changes in `package.json` and lockfile reflect the new Jotai-based state management.