### PR TITLE
Make liquidity scenarios global across projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@ NEXT_PUBLIC_CONVEX_URL=""
 NEXT_PUBLIC_CONVEX_SITE_URL=""
 
 # Better Auth (set these in the Convex deployment environment)
-SITE_URL="http://localhost:3010"
-TRUSTED_ORIGINS="http://localhost:3010,http://127.0.0.1:3010"
+SITE_URL="http://localhost:3011"
+TRUSTED_ORIGINS="http://localhost:3011,http://127.0.0.1:3011"
 BETTER_AUTH_SECRET=""
 
 # CopilotKit Runtime / OpenAI

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ after sign-in. Signed-out usage remains local to the browser.
 3. Set the Better Auth environment variables on the Convex deployment:
 
    ```bash
-   pnpm convex env set SITE_URL http://localhost:3010
-   pnpm convex env set TRUSTED_ORIGINS http://localhost:3010,http://127.0.0.1:3010,http://192.168.178.27:3010,http://10.100.100.3:3010
+   pnpm convex env set SITE_URL http://localhost:3011
+   pnpm convex env set TRUSTED_ORIGINS http://localhost:3011,http://127.0.0.1:3011,http://192.168.178.27:3011,http://10.100.100.3:3011
    pnpm convex env set BETTER_AUTH_SECRET "$(openssl rand -base64 32)"
    ```
 
@@ -64,7 +64,7 @@ after sign-in. Signed-out usage remains local to the browser.
    pnpm dev
    ```
 
-Open `http://localhost:3010`.
+Open `http://localhost:3011`.
 
 ## Coolify production
 

--- a/convex/appState.ts
+++ b/convex/appState.ts
@@ -167,6 +167,12 @@ function belongsToProject(row: { projectId?: string }, projectId: string) {
   return projectForRow(row) === projectId;
 }
 
+function withoutProjectId<T extends { projectId?: string }>(value: T) {
+  const copy = { ...value };
+  delete copy.projectId;
+  return copy;
+}
+
 function dedupeProjectRows<T extends { projectId?: string }>(
   rows: T[],
   activeProjectId: string,
@@ -179,6 +185,26 @@ function dedupeProjectRows<T extends { projectId?: string }>(
     if (
       existing === undefined ||
       (existing.projectId === undefined && row.projectId === activeProjectId)
+    ) {
+      byKey.set(key, row);
+    }
+  }
+  return [...byKey.values()];
+}
+
+function dedupeGlobalRows<T extends { projectId?: string }>(
+  rows: T[],
+  activeProjectId: string,
+  keyForRow: (row: T) => string,
+) {
+  const byKey = new Map<string, T>();
+  for (const row of rows) {
+    const key = keyForRow(row);
+    const existing = byKey.get(key);
+    if (
+      existing === undefined ||
+      row.projectId === undefined ||
+      (existing.projectId !== undefined && row.projectId === activeProjectId)
     ) {
       byKey.set(key, row);
     }
@@ -273,13 +299,13 @@ export const getForCurrentUser = query({
       activeProjectId,
       (row) => `${row.scenarioId}\u0000${row.creditId}`,
     );
-    const liquidityScenarioRows = allLiquidityScenarioRows.filter((row) =>
-      belongsToProject(row, activeProjectId),
+    const liquidityScenarioRows = dedupeGlobalRows(
+      allLiquidityScenarioRows,
+      activeProjectId,
+      (row) => row.scenarioId,
     );
-    const liquidityItemRows = dedupeProjectRows(
-      allLiquidityItemRows.filter((row) =>
-        belongsToProject(row, activeProjectId),
-      ),
+    const liquidityItemRows = dedupeGlobalRows(
+      allLiquidityItemRows,
       activeProjectId,
       (row) => `${row.scenarioId}\u0000${row.itemId}`,
     );
@@ -767,11 +793,8 @@ export const importLocalScenarios = mutation({
         q.eq("userIdentifier", userIdentifier),
       )
       .take(500);
-    const projectLiquidityRows = liquidityRows.filter((row) =>
-      belongsToProject(row, projectId),
-    );
     const liquidityNames = new Set(
-      projectLiquidityRows.map((row) => row.name.toLowerCase()),
+      liquidityRows.map((row) => row.name.toLowerCase()),
     );
     const liquidityItemRows = await ctx.db
       .query("liquidityItems")
@@ -779,9 +802,6 @@ export const importLocalScenarios = mutation({
         q.eq("userIdentifier", userIdentifier),
       )
       .take(5000);
-    const projectLiquidityItemRows = liquidityItemRows.filter((row) =>
-      belongsToProject(row, projectId),
-    );
 
     for (const candidate of args.liquidity) {
       const previousImport = await ctx.db
@@ -808,12 +828,12 @@ export const importLocalScenarios = mutation({
       const expectedCreditScenarioId =
         financingIdMap.get(candidate.scenario.creditScenarioId) ??
         candidate.scenario.creditScenarioId;
-      const contentMatch = projectLiquidityRows.find((row) =>
+      const contentMatch = liquidityRows.find((row) =>
         sameLiquidityContent(
           row,
           candidate,
           expectedCreditScenarioId,
-          projectLiquidityItemRows
+          liquidityItemRows
             .filter((item) => item.scenarioId === row.scenarioId)
             .map((item) => ({
               position: item.position,
@@ -837,14 +857,18 @@ export const importLocalScenarios = mutation({
         continue;
       }
 
-      const existing = await ctx.db
+      const existingRows = await ctx.db
         .query("liquidityScenarios")
         .withIndex("by_userIdentifier_and_scenarioId", (q) =>
           q
             .eq("userIdentifier", userIdentifier)
             .eq("scenarioId", candidate.scenario.scenarioId),
         )
-        .unique();
+        .take(500);
+      const existing =
+        existingRows.find((row) => row.projectId === undefined) ??
+        existingRows[0] ??
+        null;
       const scenarioId =
         existing === null
           ? candidate.scenario.scenarioId
@@ -855,10 +879,11 @@ export const importLocalScenarios = mutation({
           ? candidate.scenario.name
           : importedName(candidate.scenario.name, liquidityNames);
       liquidityNames.add(name.toLowerCase());
+      const liquidityScenario = withoutProjectId(candidate.scenario);
 
       const insertedScenarioId = await ctx.db.insert("liquidityScenarios", {
         userIdentifier,
-        ...candidate.scenario,
+        ...liquidityScenario,
         scenarioId,
         name,
         createdAt: importedAt,
@@ -869,18 +894,16 @@ export const importLocalScenarios = mutation({
         _id: insertedScenarioId,
         _creationTime: importedAt,
         userIdentifier,
-        ...candidate.scenario,
+        ...liquidityScenario,
         scenarioId,
         name,
         createdAt: importedAt,
         creditScenarioId: expectedCreditScenarioId,
         updatedAt: importedAt,
       });
-      projectLiquidityRows.push(liquidityRows[liquidityRows.length - 1]!);
       for (const item of candidate.items) {
         const insertedItemId = await ctx.db.insert("liquidityItems", {
           userIdentifier,
-          projectId,
           scenarioId,
           itemId: item.itemId,
           position: item.position,
@@ -891,16 +914,12 @@ export const importLocalScenarios = mutation({
           _id: insertedItemId,
           _creationTime: importedAt,
           userIdentifier,
-          projectId,
           scenarioId,
           itemId: item.itemId,
           position: item.position,
           data: item.data,
           updatedAt: importedAt,
         });
-        projectLiquidityItemRows.push(
-          liquidityItemRows[liquidityItemRows.length - 1]!,
-        );
       }
       const nextImport = {
         userIdentifier,
@@ -1105,21 +1124,23 @@ export const saveLiquidityScenario = mutation({
   handler: async (ctx, args) => {
     const identity = await requireIdentity(ctx);
     const userIdentifier = identity.tokenIdentifier;
-    const projectId = args.scenario.projectId ?? defaultProjectId;
     const updatedAt = Date.now();
-    const existingScenario = await ctx.db
+    const existingScenarios = await ctx.db
       .query("liquidityScenarios")
-      .withIndex("by_userIdentifier_and_projectId_and_scenarioId", (q) =>
+      .withIndex("by_userIdentifier_and_scenarioId", (q) =>
         q
           .eq("userIdentifier", userIdentifier)
-          .eq("projectId", projectId)
           .eq("scenarioId", args.scenario.scenarioId),
       )
-      .unique();
+      .take(500);
+    const existingScenario =
+      existingScenarios.find((row) => row.projectId === undefined) ??
+      existingScenarios[0] ??
+      null;
+    const scenario = withoutProjectId(args.scenario);
     const nextScenario = {
       userIdentifier,
-      ...args.scenario,
-      projectId,
+      ...scenario,
       updatedAt,
     };
 
@@ -1142,23 +1163,31 @@ export const saveLiquidityScenario = mutation({
         nextScenario,
       );
     }
+    for (const scenario of existingScenarios) {
+      if (existingScenario !== null && scenario._id === existingScenario._id) {
+        continue;
+      }
+      await ctx.db.delete(scenario._id);
+    }
 
     for (const item of args.items) {
-      const existingItem = await ctx.db
+      const existingItems = await ctx.db
         .query("liquidityItems")
         .withIndex(
-          "by_userIdentifier_and_projectId_and_scenarioId_and_itemId",
+          "by_userIdentifier_and_scenarioId_and_itemId",
           (q) =>
             q
               .eq("userIdentifier", userIdentifier)
-              .eq("projectId", projectId)
               .eq("scenarioId", args.scenario.scenarioId)
               .eq("itemId", item.itemId),
         )
-        .unique();
+        .take(500);
+      const existingItem =
+        existingItems.find((row) => row.projectId === undefined) ??
+        existingItems[0] ??
+        null;
       const nextItem = {
         userIdentifier,
-        projectId,
         scenarioId: args.scenario.scenarioId,
         itemId: item.itemId,
         position: item.position,
@@ -1170,17 +1199,22 @@ export const saveLiquidityScenario = mutation({
       } else if (!sameValues(existingItem, nextItem, ["position", "data"])) {
         await ctx.db.replace("liquidityItems", existingItem._id, nextItem);
       }
+      for (const duplicate of existingItems) {
+        if (existingItem !== null && duplicate._id === existingItem._id) {
+          continue;
+        }
+        await ctx.db.delete(duplicate._id);
+      }
     }
 
     const retainedItemIds = new Set(args.items.map((row) => row.itemId));
     const existingItems = await ctx.db
       .query("liquidityItems")
       .withIndex(
-        "by_userIdentifier_and_projectId_and_scenarioId_and_itemId",
+        "by_userIdentifier_and_scenarioId_and_itemId",
         (q) =>
           q
             .eq("userIdentifier", userIdentifier)
-            .eq("projectId", projectId)
             .eq("scenarioId", args.scenario.scenarioId),
       )
       .take(5000);
@@ -1199,26 +1233,23 @@ export const deleteLiquidityScenario = mutation({
   handler: async (ctx, args) => {
     const identity = await requireIdentity(ctx);
     const userIdentifier = identity.tokenIdentifier;
-    const projectId = args.projectId ?? defaultProjectId;
-    let scenario = await ctx.db
+    const scenarios = await ctx.db
       .query("liquidityScenarios")
-      .withIndex("by_userIdentifier_and_projectId_and_scenarioId", (q) =>
+      .withIndex("by_userIdentifier_and_scenarioId", (q) =>
         q
           .eq("userIdentifier", userIdentifier)
-          .eq("projectId", projectId)
           .eq("scenarioId", args.scenarioId),
       )
-      .unique();
-    if (scenario !== null) await ctx.db.delete(scenario._id);
+      .take(500);
+    for (const scenario of scenarios) await ctx.db.delete(scenario._id);
 
     const items = await ctx.db
       .query("liquidityItems")
       .withIndex(
-        "by_userIdentifier_and_projectId_and_scenarioId_and_itemId",
+        "by_userIdentifier_and_scenarioId_and_itemId",
         (q) =>
           q
             .eq("userIdentifier", userIdentifier)
-            .eq("projectId", projectId)
             .eq("scenarioId", args.scenarioId),
       )
       .take(5000);
@@ -1395,8 +1426,7 @@ async function projectSnapshot(
     ),
     liquidityItems: liquidityItemRows.filter(
       (row) =>
-        (selectedSet.size === 0 || selectedSet.has(row.scenarioId)) &&
-        belongsToProject(row, projectId),
+        selectedSet.size === 0 || selectedSet.has(row.scenarioId),
     ),
   };
 }
@@ -1834,18 +1864,22 @@ export const replaceForCurrentUser = mutation({
     }
 
     for (const scenario of args.liquidityScenarios) {
-      const existing = await ctx.db
+      const existingRows = await ctx.db
         .query("liquidityScenarios")
         .withIndex("by_userIdentifier_and_scenarioId", (q) =>
           q
             .eq("userIdentifier", userIdentifier)
             .eq("scenarioId", scenario.scenarioId),
         )
-        .unique();
+        .take(500);
+      const existing =
+        existingRows.find((row) => row.projectId === undefined) ??
+        existingRows[0] ??
+        null;
+      const liquidityScenario = withoutProjectId(scenario);
       const next = {
         userIdentifier,
-        ...scenario,
-        projectId: scenario.projectId ?? defaultProjectId,
+        ...liquidityScenario,
         updatedAt,
       };
       if (existing === null) {
@@ -1866,7 +1900,7 @@ export const replaceForCurrentUser = mutation({
     }
 
     for (const item of args.liquidityItems) {
-      const existing = await ctx.db
+      const existingRows = await ctx.db
         .query("liquidityItems")
         .withIndex("by_userIdentifier_and_scenarioId_and_itemId", (q) =>
           q
@@ -1874,11 +1908,15 @@ export const replaceForCurrentUser = mutation({
             .eq("scenarioId", item.scenarioId)
             .eq("itemId", item.itemId),
         )
-        .unique();
+        .take(500);
+      const existing =
+        existingRows.find((row) => row.projectId === undefined) ??
+        existingRows[0] ??
+        null;
+      const liquidityItem = withoutProjectId(item);
       const next = {
         userIdentifier,
-        ...item,
-        projectId: item.projectId ?? defaultProjectId,
+        ...liquidityItem,
         updatedAt,
       };
       if (existing === null) {

--- a/next.config.js
+++ b/next.config.js
@@ -8,10 +8,10 @@ import "./src/env.js";
 const config = {
   serverExternalPackages: ["@copilotkit/runtime", "express", "officeparser"],
   allowedDevOrigins: [
-    "http://localhost:3010",
-    "http://127.0.0.1:3010",
-    "http://192.168.178.27:3010",
-    "http://10.100.100.3:3010",
+    "http://localhost:3011",
+    "http://127.0.0.1:3011",
+    "http://192.168.178.27:3011",
+    "http://10.100.100.3:3011",
   ],
   async rewrites() {
     return [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "db:migrate": "prisma migrate deploy",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
-    "dev": "next dev --turbo -p 3010",
+    "dev": "next dev --turbo -p 3011",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "postinstall": "prisma generate",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3010";
+const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3011";
 
 export default defineConfig({
   testDir: "./tests/e2e",

--- a/scripts/e2e-webserver.sh
+++ b/scripts/e2e-webserver.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 export CONVEX_AGENT_MODE="${CONVEX_AGENT_MODE:-anonymous}"
 export DATABASE_URL="${DATABASE_URL:-file:./db.sqlite}"
-export SITE_URL="${SITE_URL:-http://localhost:3010}"
-export TRUSTED_ORIGINS="${TRUSTED_ORIGINS:-http://localhost:3010,http://127.0.0.1:3010}"
+export SITE_URL="${SITE_URL:-http://localhost:3011}"
+export TRUSTED_ORIGINS="${TRUSTED_ORIGINS:-http://localhost:3011,http://127.0.0.1:3011}"
 export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-e2e-better-auth-secret-at-least-32-chars}"
 
 convex_env_file="$(mktemp)"

--- a/src/state/app_state.tsx
+++ b/src/state/app_state.tsx
@@ -359,7 +359,6 @@ function toConvexSnapshot(state: SyncedState) {
       return [
         {
           scenarioId: scenario.id,
-          projectId,
           name: scenario.name,
           createdAt: scenario.createdAt,
           color: scenario.color,
@@ -375,7 +374,6 @@ function toConvexSnapshot(state: SyncedState) {
     ([scenarioId, values]) =>
       values.items.map((data, position) => ({
         scenarioId,
-        projectId,
         itemId: data.id,
         position,
         data,
@@ -559,13 +557,11 @@ function scenarioMutationPayload(
 }
 
 function liquidityMutationPayload(
-  projectId: string,
   scenario: LiquidityScenario,
   values: LiquidityScenarioValues,
 ) {
   return {
     scenario: {
-      projectId,
       scenarioId: scenario.id,
       name: scenario.name,
       createdAt: scenario.createdAt,
@@ -863,7 +859,6 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
       if (shareToken !== undefined) return;
       await saveLiquidityScenarioMutation(
         liquidityMutationPayload(
-          state.activeProjectId,
           scenario,
           normalizeLiquidityScenarioValues(values),
         ),
@@ -1097,7 +1092,6 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
           (scenario) => scenario.id !== scenarioId,
         );
         await deleteLiquidityScenarioMutation({
-          projectId: state.activeProjectId,
           scenarioId,
         });
         await setSettings({


### PR DESCRIPTION
## Summary
- Removed `projectId` scoping from liquidity scenario and item persistence so liquidity data is shared globally instead of per project.
- Updated import, save, replace, delete, and snapshot logic to dedupe and clean up legacy duplicate rows while preferring global records.
- Bumped local/dev and E2E defaults from `3010` to `3011` in app config, docs, and environment examples.

## Testing
- Not run (not requested).
- Not run: `pnpm typecheck`.
- Not run: `pnpm test:unit`.
- Not run: `pnpm test:e2e`.